### PR TITLE
Added LessThanOrEqualTo and GreaterThanOrEqualTo assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ AssertThat(x, IsLessThan(3));
 AssertThat(x, Is().LessThan(3));
 ```
 
+####GreaterThanOrEqualTo Constraint
+
+Used to verify that actual is greater than or equal to a value.
+
+```cpp
+AssertThat(x, IsGreaterThanOrEqualTo(5));
+AssertThat(x, Is().GreaterThanOrEqualTo(5));
+```
+
+####LessThanOrEqualTo Constraint
+
+Used to verify that actual is less than or equal to a value.
+
+```cpp
+AssertThat(x, IsLessThanOrEqualTo(6));
+AssertThat(x, Is().LessThanOrEqualTo(6));
+```
+
 ### String Constraints
 
 String assertions in Snowhouse are used to verify the values of STL strings (std::string).

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -114,13 +114,25 @@ void BasicAssertions()
 	{
 		Assert::That(5, IsGreaterThan(4));
 	}
+
+  std::cout << "ShouldHandleGreaterThanOrEqualTo" << std::endl;
+	{
+		Assert::That(4, IsGreaterThanOrEqualTo(4));
+		Assert::That(5, IsGreaterThanOrEqualTo(4));
+	}
 	
   std::cout << "ShouldDetectWhenGreaterThanFails" << std::endl;
 	{
 		AssertTestFails(Assert::That(5, IsGreaterThan(5)),
         "Expected: greater than 5\nActual: 5\n");
 	}
-	
+
+  std::cout << "ShouldDetectWhenGreaterThanOrEqualToFails" << std::endl;
+	{
+		AssertTestFails(Assert::That(4, IsGreaterThanOrEqualTo(5)),
+        "Expected: greater than or equal to 5\nActual: 4\n");
+	}
+
   std::cout << "ShouldHandleLessThan" << std::endl;
 	{
 		Assert::That(5, IsLessThan(6));

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -137,10 +137,22 @@ void BasicAssertions()
 	{
 		Assert::That(5, IsLessThan(6));
 	}
+
+  std::cout << "ShouldHandleLessThanOrEqualTo" << std::endl;
+	{
+		Assert::That(5, IsLessThanOrEqualTo(6));
+		Assert::That(6, IsLessThanOrEqualTo(6));
+	}
 	
   std::cout << "ShouldDetectWhenLessThanFails" << std::endl;
 	{
 		AssertTestFails(Assert::That(6, IsLessThan(5)),
         "Expected: less than 5\nActual: 6\n");
+	}
+
+  std::cout << "ShouldDetectWhenLessThanOrEqualToFails" << std::endl;
+	{
+		AssertTestFails(Assert::That(6, IsLessThanOrEqualTo(5)),
+			"Expected: less than or equal to 5\nActual: 6\n");
 	}
 }

--- a/snowhouse/constraints/constraints.h
+++ b/snowhouse/constraints/constraints.h
@@ -12,6 +12,7 @@
 #include "equalsconstraint.h"
 #include "haslengthconstraint.h"
 #include "isgreaterthanconstraint.h"
+#include "isgreaterthanorequaltoconstraint.h"
 #include "islessthanconstraint.h"
 #include "startswithconstraint.h"
 #include "fulfillsconstraint.h"

--- a/snowhouse/constraints/constraints.h
+++ b/snowhouse/constraints/constraints.h
@@ -14,6 +14,7 @@
 #include "isgreaterthanconstraint.h"
 #include "isgreaterthanorequaltoconstraint.h"
 #include "islessthanconstraint.h"
+#include "islessthanorequaltoconstraint.h"
 #include "startswithconstraint.h"
 #include "fulfillsconstraint.h"
 #include "equalswithdeltaconstraint.h"

--- a/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
+++ b/snowhouse/constraints/isgreaterthanorequaltoconstraint.h
@@ -1,0 +1,55 @@
+
+//          Copyright Joakim Karlsson & Kim Gräsman 2010-2012.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef IGLOO_ISGREATERTHANOREQUALTOCONSTRAINT_H
+#define IGLOO_ISGREATERTHANOREQUALTOCONSTRAINT_H
+
+#include "./expressions/expression.h"
+
+namespace snowhouse {
+
+  template< typename ExpectedType >
+  struct IsGreaterThanOrEqualToConstraint : Expression < IsGreaterThanOrEqualToConstraint<ExpectedType> >
+  {
+    IsGreaterThanOrEqualToConstraint(const ExpectedType& expected)
+      : m_expected(expected)
+    {
+    }
+
+    template<typename ActualType>
+    bool operator()(const ActualType& actual) const
+    {
+      return (actual >= m_expected);
+    }
+
+    ExpectedType m_expected;
+  };
+
+  template< typename ExpectedType >
+  inline IsGreaterThanOrEqualToConstraint<ExpectedType> IsGreaterThanOrEqualTo(const ExpectedType& expected)
+  {
+    return IsGreaterThanOrEqualToConstraint<ExpectedType>(expected);
+  }
+
+  inline IsGreaterThanOrEqualToConstraint<std::string> IsGreaterThanOrEqualTo(const char* expected)
+  {
+    return IsGreaterThanOrEqualToConstraint<std::string>(expected);
+  }
+
+  template< typename ExpectedType >
+  struct Stringizer < IsGreaterThanOrEqualToConstraint< ExpectedType > >
+  {
+    static std::string ToString(const IsGreaterThanOrEqualToConstraint<ExpectedType>& constraint)
+    {
+      std::ostringstream builder;
+      builder << "greater than or equal to " << snowhouse::Stringize(constraint.m_expected);
+
+      return builder.str();
+    }
+  };
+}
+
+#endif

--- a/snowhouse/constraints/islessthanorequaltoconstraint.h
+++ b/snowhouse/constraints/islessthanorequaltoconstraint.h
@@ -1,0 +1,55 @@
+
+//          Copyright Joakim Karlsson & Kim Gräsman 2010-2012.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef IGLOO_ISLESSTHANOREQUALTOCONSTRAINT_H
+#define IGLOO_ISLESSTHANOREQUALTOCONSTRAINT_H
+
+#include "./expressions/expression.h"
+
+namespace snowhouse {
+
+  template< typename ExpectedType >
+  struct IsLessThanOrEqualToConstraint : Expression < IsLessThanOrEqualToConstraint<ExpectedType> >
+  {
+    IsLessThanOrEqualToConstraint(const ExpectedType& expected)
+      : m_expected(expected)
+    {
+    }
+
+    template<typename ActualType>
+    bool operator()(const ActualType& actual) const
+    {
+      return (actual <= m_expected);
+    }
+
+    ExpectedType m_expected;
+  };
+
+  template< typename ExpectedType >
+  inline IsLessThanOrEqualToConstraint<ExpectedType> IsLessThanOrEqualTo(const ExpectedType& expected)
+  {
+    return IsLessThanOrEqualToConstraint<ExpectedType>(expected);
+  }
+
+  inline IsLessThanOrEqualToConstraint<std::string> IsLessThanOrEqualTo(const char* expected)
+  {
+    return IsLessThanOrEqualToConstraint<std::string>(expected);
+  }
+
+  template< typename ExpectedType >
+  struct Stringizer < IsLessThanOrEqualToConstraint< ExpectedType > >
+  {
+    static std::string ToString(const IsLessThanOrEqualToConstraint<ExpectedType>& constraint)
+    {
+      std::ostringstream builder;
+      builder << "less than or equal to " << snowhouse::Stringize(constraint.m_expected);
+
+      return builder.str();
+    }
+  };
+}
+
+#endif

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -27,7 +27,7 @@ namespace snowhouse {
     ExpressionBuilder(const ConstraintListType& list) : m_constraint_list(list)
     {
     }
-    
+
     template <typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<ExpectedType> >, Nil> >::t> 
       EqualTo(const ExpectedType& expected)
@@ -85,18 +85,30 @@ namespace snowhouse {
       return EqualTo<std::string>(std::string(expected));
     }
     
-    template <typename ExpectedType>
-    ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> >, Nil> >::t> 
-      GreaterThan(const ExpectedType& expected)
-    {
-      typedef ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> > ConstraintAdapterType;
-      
-      typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
-      ConstraintAdapterType constraint(expected);
-      ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
-      return BuilderType(Concatenate(m_constraint_list, node));
-    }   
-    
+	template <typename ExpectedType>
+	ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> >, Nil> >::t>
+		GreaterThan(const ExpectedType& expected)
+	{
+		typedef ConstraintAdapter<IsGreaterThanConstraint<ExpectedType> > ConstraintAdapterType;
+
+		typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+		ConstraintAdapterType constraint(expected);
+		ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
+		return BuilderType(Concatenate(m_constraint_list, node));
+	}
+
+	template <typename ExpectedType>
+	ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
+		GreaterThanOrEqualTo(const ExpectedType& expected)
+	{
+		typedef ConstraintAdapter<IsGreaterThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
+
+		typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+		ConstraintAdapterType constraint(expected);
+		ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
+		return BuilderType(Concatenate(m_constraint_list, node));
+	}
+
     template <typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanConstraint<ExpectedType> >, Nil> >::t> 
     LessThan(const ExpectedType& expected)

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -121,6 +121,18 @@ namespace snowhouse {
       return BuilderType(Concatenate(m_constraint_list, node));
     } 
     
+	template <typename ExpectedType>
+	ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> >, Nil> >::t>
+		LessThanOrEqualTo(const ExpectedType& expected)
+	{
+		typedef ConstraintAdapter<IsLessThanOrEqualToConstraint<ExpectedType> > ConstraintAdapterType;
+
+		typedef ExpressionBuilder< typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapterType, Nil> >::t > BuilderType;
+		ConstraintAdapterType constraint(expected);
+		ConstraintList<ConstraintAdapterType, Nil> node(constraint, Nil());
+		return BuilderType(Concatenate(m_constraint_list, node));
+	}
+
     template <typename ExpectedType>
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<ContainsConstraint<ExpectedType> >, Nil> >::t> 
       Containing(const ExpectedType& expected)


### PR DESCRIPTION
I felt it was a bit verbose when checking if a value was within an inclusive range, and I did not like having to enter the same value twice, so I added two new assertions.

Now instead of writing something like:
```cpp
Assert::That(value, Is().GreaterThan(0).Or().EqualTo(0).And().LessThan(180).Or().EqualTo(180));
```

you can write:
```cpp
Assert::That(value, Is().GreaterThanOrEqualTo(0).And().LessThanOrEqualTo(180));
```

I was considering adding some kind of "Between" assertion, but I wasn't sure how you would specify whether the start and end values are inclusive or exclusive so I did this instead.