### PR TITLE
Configurable error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,3 +372,7 @@ Expected: To fullfill my constraint
 Actual: MyType( x = 23 )
 ```
 
+##Configurable Failure Handlers
+
+You can provide Snowhouse with custom failure handlers, for example to call `std::terminate` instead of throwing an exception. See `DefaultFailureHandler` for an example of a failure handler. You can derive your own macros with custom failure handlers using `SNOWHOUSE_ASSERT_THAT` and `SNOWHOUSE_ASSERT_THROWS`. See the definitions of `AssertThat` and `AssertThrows` for an example of these. You can define `SNOWHOUSE_NO_MACROS` to disable the unprefixed macros `AssertThat` and `AssertThrows`.
+

--- a/README.md
+++ b/README.md
@@ -374,5 +374,19 @@ Actual: MyType( x = 23 )
 
 ##Configurable Failure Handlers
 
-You can provide Snowhouse with custom failure handlers, for example to call `std::terminate` instead of throwing an exception. See `DefaultFailureHandler` for an example of a failure handler. You can derive your own macros with custom failure handlers using `SNOWHOUSE_ASSERT_THAT` and `SNOWHOUSE_ASSERT_THROWS`. See the definitions of `AssertThat` and `AssertThrows` for an example of these. You can define `SNOWHOUSE_NO_MACROS` to disable the unprefixed macros `AssertThat` and `AssertThrows`.
+You can provide Snowhouse with custom failure handlers, for example to call `std::terminate` instead of throwing an exception. See `DefaultFailureHandler` for an example of a failure handler. You can derive your own macros with custom failure handlers using `SNOWHOUSE_ASSERT_THAT` and `SNOWHOUSE_ASSERT_THROWS`. See the definitions of `AssertThat` and `AssertThrows` for examples of these. Define `SNOWHOUSE_NO_MACROS` to disable the unprefixed macros `AssertThat` and `AssertThrows`.
+
+### Example Use Cases
+
+#### Assert Program State
+
+Log an error immediately as we may crash if we try to continue. Don't attempt to unwind the stack as we may be inside a destructor or `nothrow` function. We may want to call `std::terminate`, or attempt to muddle along with the rest of the program.
+
+#### Assert Program State in Safe Builds
+
+As above, but only in debug builds.
+
+#### Test Assert
+
+Assert that a test behaved as expected. Throw an exception and let our testing framework deal with the test failure.
 

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -2,6 +2,17 @@
 using namespace snowhouse;
 #include "tests.h"
 
+struct IgnoreErrors {
+   template <class ExpectedType, class ActualType>
+   static void handle(const ExpectedType&, const ActualType&, const char*, int)
+   {
+   }
+
+   static void handle(const std::string&)
+   {
+   }
+};
+
 void BasicAssertions()
 {
   std::cout << "================================================" << std::endl;
@@ -78,6 +89,11 @@ void BasicAssertions()
     Assert::That(line, Equals(32));
     Assert::That(file, Equals("filename"));
   }
+
+  std::cout << "ShouldIgnoreTheError" << std::endl;  
+	{
+		ConfigurableAssert<IgnoreErrors>::That(1, Equals(2));		
+	}
 
   std::cout << "================================================" << std::endl;
   std::cout << "    ASSERTIONS EXPRESSION TEMPLATES" << std::endl;

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -1,6 +1,11 @@
+#include <stdexcept>
 #include <snowhouse/snowhouse.h>
 using namespace snowhouse;
 #include "tests.h"
+
+void throwRuntimeError() {
+   throw std::runtime_error("This is expected");
+}
 
 struct IgnoreErrors {
    template <class ExpectedType, class ActualType>
@@ -90,10 +95,16 @@ void BasicAssertions()
     Assert::That(file, Equals("filename"));
   }
 
+  std::cout << "ShouldEnsureExceptionIsThrown" << std::endl;  
+    {
+          
+      AssertThrows(std::runtime_error, throwRuntimeError());
+    }
+
   std::cout << "ShouldIgnoreTheError" << std::endl;  
-	{
-		ConfigurableAssert<IgnoreErrors>::That(1, Equals(2));		
-	}
+    {
+      ConfigurableAssert<IgnoreErrors>::That(1, Equals(2));
+    }
 
   std::cout << "================================================" << std::endl;
   std::cout << "    ASSERTIONS EXPRESSION TEMPLATES" << std::endl;

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -4,11 +4,11 @@ using namespace snowhouse;
 
 struct IgnoreErrors {
    template <class ExpectedType, class ActualType>
-   static void handle(const ExpectedType&, const ActualType&, const char*, int)
+   static void Handle(const ExpectedType&, const ActualType&, const char*, int)
    {
    }
 
-   static void handle(const std::string&)
+   static void Handle(const std::string&)
    {
    }
 };

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -118,9 +118,6 @@ namespace snowhouse {
       {
          FailureHandler::Handle(message);
       }
-
-   private:
-      FailureHandler assertHandler;
    };
 
    typedef ConfigurableAssert<DefaultFailureHandler> Assert;

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -15,7 +15,7 @@ namespace snowhouse {
    struct DefaultFailureHandler
    {
       template <class ExpectedType, class ActualType>
-      static void handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
+      static void Handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
       {
          std::ostringstream str;
 
@@ -25,7 +25,7 @@ namespace snowhouse {
          throw AssertionException(str.str(), file_name, line_number);
       }
 
-      static void handle(const std::string& message)
+      static void Handle(const std::string& message)
       {
          throw AssertionException(message);
       }
@@ -68,12 +68,12 @@ namespace snowhouse {
 
             if (!result.top())
             {
-               FailureHandler::handle(expression, actual, file_name, line_number);
+               FailureHandler::Handle(expression, actual, file_name, line_number);
             }      
          }
          catch (const InvalidExpressionException& e) 
          {
-            FailureHandler::handle("Malformed expression: \"" + snowhouse::Stringize(expression) + "\"\n" + e.Message());
+            FailureHandler::Handle("Malformed expression: \"" + snowhouse::Stringize(expression) + "\"\n" + e.Message());
          }
       }
 
@@ -96,7 +96,7 @@ namespace snowhouse {
       {
          if (!expression(actual))
          {
-            FailureHandler::handle(expression, actual, file_name, line_number);
+            FailureHandler::Handle(expression, actual, file_name, line_number);
          }
       }
 
@@ -110,13 +110,13 @@ namespace snowhouse {
       {
          if (!actual)
          {
-            FailureHandler::handle("Expected: true\nActual: false");
+            FailureHandler::Handle("Expected: true\nActual: false");
          }
       }
 
       static void Failure(const std::string& message)
       {
-         FailureHandler::handle(message);
+         FailureHandler::Handle(message);
       }
 
    private:

--- a/snowhouse/assert.h
+++ b/snowhouse/assert.h
@@ -12,7 +12,27 @@
 
 namespace snowhouse {
 
-   class Assert
+   struct DefaultFailureHandler
+   {
+      template <class ExpectedType, class ActualType>
+      static void handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
+      {
+         std::ostringstream str;
+
+         str << "Expected: " << snowhouse::Stringize(expected) << std::endl;
+         str << "Actual: " << snowhouse::Stringize(actual) << std::endl;
+
+         throw AssertionException(str.str(), file_name, line_number);
+      }
+
+      static void handle(const std::string& message)
+      {
+         throw AssertionException(message);
+      }
+   };
+
+   template<typename FailureHandler>
+   class ConfigurableAssert
    {
    public:
 
@@ -22,7 +42,7 @@ namespace snowhouse {
         const char* no_file = "";
         int line_number = 0;
 
-        Assert::That(actual, expression, no_file, line_number);
+        ConfigurableAssert<FailureHandler>::That(actual, expression, no_file, line_number);
       }
       
       template <typename ActualType, typename ConstraintListType>
@@ -48,12 +68,12 @@ namespace snowhouse {
 
             if (!result.top())
             {
-               throw AssertionException(CreateErrorText(expression, actual), file_name, line_number);
+               FailureHandler::handle(expression, actual, file_name, line_number);
             }      
          }
          catch (const InvalidExpressionException& e) 
          {
-            throw AssertionException("Malformed expression: \"" + snowhouse::Stringize(expression) + "\"\n" + e.Message());
+            FailureHandler::handle("Malformed expression: \"" + snowhouse::Stringize(expression) + "\"\n" + e.Message());
          }
       }
 
@@ -76,7 +96,7 @@ namespace snowhouse {
       {
          if (!expression(actual))
          {
-            throw AssertionException(CreateErrorText(expression, actual), file_name, line_number);
+            FailureHandler::handle(expression, actual, file_name, line_number);
          }
       }
 
@@ -90,27 +110,20 @@ namespace snowhouse {
       {
          if (!actual)
          {
-            throw AssertionException("Expected: true\nActual: false");
+            FailureHandler::handle("Expected: true\nActual: false");
          }
       }
 
       static void Failure(const std::string& message)
       {
-         throw AssertionException(message);
+         FailureHandler::handle(message);
       }
 
    private:
-      template <class ExpectedType, class ActualType>
-      static std::string CreateErrorText(const ExpectedType& expected, const ActualType& actual)
-      {
-         std::ostringstream str;
-
-         str << "Expected: " << snowhouse::Stringize(expected) << std::endl;
-         str << "Actual: " << snowhouse::Stringize(actual) << std::endl;
-
-         return str.str();
-      }
+      FailureHandler assertHandler;
    };
+
+   typedef ConfigurableAssert<DefaultFailureHandler> Assert;
 }
 
 #endif	// IGLOO_ASSERT_H

--- a/snowhouse/assertmacro.h
+++ b/snowhouse/assertmacro.h
@@ -9,7 +9,11 @@
 
 #include "assert.h"
 
+#ifndef SNOWHOUSE_NO_MACROS
+
 #define AssertThat(p1,p2)\
   Assert::That((p1), (p2), __FILE__, __LINE__);\
+
+#endif // SNOWHOUSE_NO_MACROS
 
 #endif	// IGLOO_ASSERTMACRO_H

--- a/snowhouse/assertmacro.h
+++ b/snowhouse/assertmacro.h
@@ -9,10 +9,13 @@
 
 #include "assert.h"
 
+#define SNOWHOUSE_ASSERT_THAT(p1,p2,FAILURE_HANDLER)\
+  ConfigurableAssert<FAILURE_HANDLER>::That((p1), (p2), __FILE__, __LINE__);\
+
 #ifndef SNOWHOUSE_NO_MACROS
 
 #define AssertThat(p1,p2)\
-  Assert::That((p1), (p2), __FILE__, __LINE__);\
+  SNOWHOUSE_ASSERT_THAT((p1), (p2), DefaultFailureHandler);\
 
 #endif // SNOWHOUSE_NO_MACROS
 

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -77,7 +77,7 @@ namespace snowhouse {
 #define IGLOO_CONCAT2(a, b) a##b
 #define IGLOO_CONCAT(a, b) IGLOO_CONCAT2(a, b)
 
-#define AssertThrows(EXCEPTION_TYPE, METHOD) \
+#define SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, METHOD) \
 ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_CONCAT(IGLOO_storage_, __LINE__).compiler_thinks_i_am_unused(); \
 { \
   bool wrong_exception = false; \
@@ -108,6 +108,12 @@ ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_C
     Assert::Failure(stm.str()); \
   } \
 }
+
+#ifndef SNOWHOUSE_NO_MACROS
+
+#define AssertThrows SNOWHOUSE_ASSERT_THROWS
+
+#endif // SNOWHOUSE_NO_MACROS
 
 #endif
 

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -77,7 +77,7 @@ namespace snowhouse {
 #define IGLOO_CONCAT2(a, b) a##b
 #define IGLOO_CONCAT(a, b) IGLOO_CONCAT2(a, b)
 
-#define SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, METHOD) \
+#define SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, METHOD, FAILURE_HANDLER_TYPE) \
 ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_CONCAT(IGLOO_storage_, __LINE__).compiler_thinks_i_am_unused(); \
 { \
   bool wrong_exception = false; \
@@ -99,19 +99,19 @@ ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_C
   { \
     std::ostringstream stm; \
     stm << "Expected " << #EXCEPTION_TYPE << ". No exception was thrown."; \
-    Assert::Failure(stm.str()); \
+    ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \
   if(wrong_exception) \
   { \
     std::ostringstream stm; \
     stm << "Expected " << #EXCEPTION_TYPE << ". Wrong exception was thrown."; \
-    Assert::Failure(stm.str()); \
+    ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \
 }
 
 #ifndef SNOWHOUSE_NO_MACROS
 
-#define AssertThrows SNOWHOUSE_ASSERT_THROWS
+#define AssertThrows(EXCEPTION_TYPE, METHOD) SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, (METHOD), DefaultFailureHandler)
 
 #endif // SNOWHOUSE_NO_MACROS
 

--- a/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
+++ b/snowhouse/fluent/operators/collections/collectionconstraintevaluator.h
@@ -8,7 +8,7 @@
 #define IGLOO_COLLECTIONCONSTRAINTEVALUATOR_H
 
 #include <string>
-#include "../../../assertionexception.h"
+#include "../invalidexpressionexception.h"
 
 namespace snowhouse
 {
@@ -91,7 +91,7 @@ private:
     std::ostringstream stm;
     stm << "This string seems to contain an invalid line ending at position "
         << newline << ":\n" << str << std::endl;
-    throw AssertionException(stm.str());
+    throw InvalidExpressionException(stm.str());
   }
 };
 

--- a/snowhouse/fluent/operators/constraintoperator.h
+++ b/snowhouse/fluent/operators/constraintoperator.h
@@ -7,22 +7,10 @@
 #ifndef IGLOO_CONTRAINTOPERATOR_H
 #define IGLOO_CONTRAINTOPERATOR_H
 
+#include "invalidexpressionexception.h"
+
 namespace snowhouse {
   
-  struct InvalidExpressionException
-  {
-    InvalidExpressionException(const std::string& message) : m_message(message)
-    {
-    }
-
-    const std::string& Message() const
-    {
-      return m_message;
-    }
-
-    std::string m_message;
-  };
-
   struct ConstraintOperator
   {
     virtual ~ConstraintOperator() {}

--- a/snowhouse/fluent/operators/invalidexpressionexception.h
+++ b/snowhouse/fluent/operators/invalidexpressionexception.h
@@ -1,0 +1,28 @@
+
+//          Copyright Joakim Karlsson & Kim Gräsman 2010-2012.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef IGLOO_INVALUDEXPRESSIONEXCEPTION_H
+#define IGLOO_INVALUDEXPRESSIONEXCEPTION_H
+
+namespace snowhouse {
+  
+  struct InvalidExpressionException
+  {
+    InvalidExpressionException(const std::string& message) : m_message(message)
+    {
+    }
+
+    const std::string& Message() const
+    {
+      return m_message;
+    }
+
+    std::string m_message;
+  };
+  
+}
+
+#endif // IGLOO_INVALUDEXPRESSIONEXCEPTION_H


### PR DESCRIPTION
Hi Joakim,

I've added the ability to configure error handling in the branch "configurable_error_handling". See README.md for some example use cases.

When using snowhouse like I'm intending, I'd like to define my own macros, some for testing, some for asserting program state, and some for debug mode only assertions. I've added a macro that can be used to disable the unprefixed macros.

What do you think? It would be great to get this merged into master and cxx11.

Regards,

Simon