### PR TITLE
Pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ AssertThat(x, IsLessThanOrEqualTo(6));
 AssertThat(x, Is().LessThanOrEqualTo(6));
 ```
 
+### Pointer Constraints
+
+Used to check for ''nullptr'' equality.
+
+```cpp
+AssertThat(x, IsNull());
+AssertThat(x, Is().Null());
+```
+
 ### String Constraints
 
 String assertions in Snowhouse are used to verify the values of STL strings (std::string).
@@ -138,7 +147,7 @@ String assertions in Snowhouse are used to verify the values of STL strings (std
 Used to verify that actual is equal to an expected value.
 
 ```cpp
-Assert:That(actual_str, Equals("foo")); 
+AssertThat(actual_str, Equals("foo")); 
 AssertThat(actual_str, Is().EqualTo("foo"));
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ AssertThat(x, Is().LessThanOrEqualTo(6));
 
 ### Pointer Constraints
 
-Used to check for ''nullptr'' equality.
+Used to check for `nullptr` equality.
 
 ```cpp
 AssertThat(x, IsNull());

--- a/example/basic_assertions.cpp
+++ b/example/basic_assertions.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <sstream>
 #include <snowhouse/snowhouse.h>
 using namespace snowhouse;
 #include "tests.h"
@@ -182,4 +183,43 @@ void BasicAssertions()
 		AssertTestFails(Assert::That(6, IsLessThanOrEqualTo(5)),
 			"Expected: less than or equal to 5\nActual: 6\n");
 	}
+
+  std::cout << "ShouldHandleNull" << std::endl;
+    {
+       Assert::That(nullptr, IsNull());
+    }
+
+  std::cout << "ShouldHandleNull" << std::endl;
+    {
+       Assert::That(nullptr, Is().Null());
+    }
+
+  std::cout << "ShouldHandleNotNull" << std::endl;
+    {
+       int anInt = 0;
+       Assert::That(&anInt, ! IsNull());
+    }
+
+  std::cout << "ShouldDetectWhenIsNullFails" << std::endl;
+    {
+       int anInt = 0;
+       std::ostringstream message;
+       message << "Expected: equal to nullptr\nActual: " << &anInt << "\n";
+       AssertTestFails(Assert::That(&anInt, IsNull()), message.str());
+    }
+
+  std::cout << "ShouldDetectWhenIsNullFails" << std::endl;
+    {
+       int anInt = 0;
+       std::ostringstream message;
+       message << "Expected: equal to nullptr\nActual: " << &anInt << "\n";
+       AssertTestFails(Assert::That(&anInt, Is().Null()), message.str());
+    }
+
+  std::cout << "ShouldDetectWhenIsNotNullFails" << std::endl;
+    {
+       std::ostringstream message;
+       message << "Expected: not equal to nullptr\nActual: nullptr\n";
+       AssertTestFails(Assert::That(nullptr, ! IsNull()), message.str());
+    }
 }

--- a/snowhouse/assertmacro.h
+++ b/snowhouse/assertmacro.h
@@ -10,12 +10,12 @@
 #include "assert.h"
 
 #define SNOWHOUSE_ASSERT_THAT(p1,p2,FAILURE_HANDLER)\
-  ConfigurableAssert<FAILURE_HANDLER>::That((p1), (p2), __FILE__, __LINE__);\
+  ::snowhouse::ConfigurableAssert<FAILURE_HANDLER>::That((p1), (p2), __FILE__, __LINE__);\
 
 #ifndef SNOWHOUSE_NO_MACROS
 
 #define AssertThat(p1,p2)\
-  SNOWHOUSE_ASSERT_THAT((p1), (p2), DefaultFailureHandler);\
+  SNOWHOUSE_ASSERT_THAT((p1), (p2), ::snowhouse::DefaultFailureHandler);\
 
 #endif // SNOWHOUSE_NO_MACROS
 

--- a/snowhouse/constraints/equalsconstraint.h
+++ b/snowhouse/constraints/equalsconstraint.h
@@ -7,6 +7,8 @@
 #ifndef IGLOO_EQUALSCONSTRAINT_H
 #define IGLOO_EQUALSCONSTRAINT_H
 
+#include <cstddef>
+
 #include "./expressions/expression.h"
 
 namespace snowhouse {
@@ -47,6 +49,11 @@ namespace snowhouse {
   inline EqualsConstraint<bool> IsTrue()
   {
     return EqualsConstraint<bool>(true);
+  }
+
+  inline EqualsConstraint<std::nullptr_t> IsNull()
+  {
+    return EqualsConstraint<std::nullptr_t>(nullptr);
   }
 
   template <>

--- a/snowhouse/exceptions.h
+++ b/snowhouse/exceptions.h
@@ -78,7 +78,7 @@ namespace snowhouse {
 #define IGLOO_CONCAT(a, b) IGLOO_CONCAT2(a, b)
 
 #define SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, METHOD, FAILURE_HANDLER_TYPE) \
-ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_CONCAT(IGLOO_storage_, __LINE__).compiler_thinks_i_am_unused(); \
+::snowhouse::ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_CONCAT(IGLOO_storage_, __LINE__).compiler_thinks_i_am_unused(); \
 { \
   bool wrong_exception = false; \
   bool no_exception = false; \
@@ -89,7 +89,7 @@ ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_C
   } \
   catch (const EXCEPTION_TYPE& e) \
   { \
-    ExceptionStorage<EXCEPTION_TYPE>::store(e); \
+    ::snowhouse::ExceptionStorage<EXCEPTION_TYPE>::store(e); \
   } \
   catch(...) \
   { \
@@ -99,19 +99,19 @@ ExceptionStorage<EXCEPTION_TYPE> IGLOO_CONCAT(IGLOO_storage_, __LINE__); IGLOO_C
   { \
     std::ostringstream stm; \
     stm << "Expected " << #EXCEPTION_TYPE << ". No exception was thrown."; \
-    ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
+    ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \
   if(wrong_exception) \
   { \
     std::ostringstream stm; \
     stm << "Expected " << #EXCEPTION_TYPE << ". Wrong exception was thrown."; \
-    ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
+    ::snowhouse::ConfigurableAssert<FAILURE_HANDLER_TYPE>::Failure(stm.str()); \
   } \
 }
 
 #ifndef SNOWHOUSE_NO_MACROS
 
-#define AssertThrows(EXCEPTION_TYPE, METHOD) SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, (METHOD), DefaultFailureHandler)
+#define AssertThrows(EXCEPTION_TYPE, METHOD) SNOWHOUSE_ASSERT_THROWS(EXCEPTION_TYPE, (METHOD), ::snowhouse::DefaultFailureHandler)
 
 #endif // SNOWHOUSE_NO_MACROS
 

--- a/snowhouse/fluent/expressionbuilder.h
+++ b/snowhouse/fluent/expressionbuilder.h
@@ -7,6 +7,8 @@
 #ifndef IGLOO_EXPRESSIONBUILDER_H
 #define IGLOO_EXPRESSIONBUILDER_H
 
+#include <cstddef>
+
 namespace snowhouse {
   
   // ---- Evaluation of list of constraints
@@ -77,6 +79,12 @@ namespace snowhouse {
       True()
     {
       return EqualTo<bool>(true);
+    }
+
+    ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<std::nullptr_t> >, Nil> >::t> 
+      Null()
+    {
+      return EqualTo<std::nullptr_t>(nullptr);
     }
 
     ExpressionBuilder<typename type_concat<ConstraintListType, ConstraintList<ConstraintAdapter<EqualsConstraint<std::string> >, Nil> >::t> 

--- a/snowhouse/stringize.h
+++ b/snowhouse/stringize.h
@@ -7,6 +7,8 @@
 #ifndef IGLOO_STRINGIZE_H
 #define IGLOO_STRINGIZE_H
 
+#include <cstddef>
+
 namespace snowhouse {
   namespace detail {
 
@@ -83,6 +85,16 @@ namespace snowhouse {
     static std::string ToString(const T& value)
     {
       return detail::DefaultStringizer< T, detail::is_output_streamable<T>::value >::ToString(value);
+    }
+  };
+
+  // We need this because nullptr_t has ambiguous overloads of operator<< in the standard library.
+  template<>
+  struct Stringizer<std::nullptr_t>
+  {
+    static std::string ToString(std::nullptr_t)
+    {
+      return "nullptr";
     }
   };
 }


### PR DESCRIPTION
Hey, I've made a couple more changes. Let me know what you think as it would be great to get them merged in. They're for the cxx11 branch only, but I could port some of them to master if you want.

I added an IsNull() and fluent Null(). I've also fixed Stringize for nullptr_t (so you could say `Equals(nullptr)` instead of `IsNull()`).

Also, the macros are no longer reliant on `using namespace snowhouse`.

Thanks,

Simon