### PR TITLE
fix shadowed variable `e` in SNOWHOUSE_ASSERT_THROWS

### DIFF
--- a/include/snowhouse/exceptions.h
+++ b/include/snowhouse/exceptions.h
@@ -99,12 +99,12 @@ namespace snowhouse
   catch (...) \
   { \
     SNOWHOUSE_TEMPVAR(wrong_exception) = true; \
-    if (auto eptr = std::current_exception()) { \
+    if (auto SNOWHOUSE_TEMPVAR(eptr) = std::current_exception()) { \
       try { \
-        std::rethrow_exception(eptr); \
-      } catch (const std::exception& e) { \
+        std::rethrow_exception(SNOWHOUSE_TEMPVAR(eptr)); \
+      } catch (const std::exception& SNOWHOUSE_TEMPVAR(e)) { \
         SNOWHOUSE_TEMPVAR(more_info) = true; \
-        SNOWHOUSE_TEMPVAR(info_string) = e.what(); \
+        SNOWHOUSE_TEMPVAR(info_string) = SNOWHOUSE_TEMPVAR(e).what(); \
       } catch (...) {} \
     } \
   } \


### PR DESCRIPTION
Seems like some `SNOWHOUSE_TEMPVAR`s were overlooked, see [here](https://github.com/ogdf/ogdf/actions/runs/8329597060/job/22792417564?pr=238#step:9:5630) for an example where this turned into a problem.